### PR TITLE
Fix invalid closing quote in HEIC error message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,7 +159,7 @@ export default function AsciiArtApp() {
     const lowerName = (file.name || "").toLowerCase();
     const looksHeic = type.includes("heic") || type.includes("heif") || lowerName.endsWith(".heic") || lowerName.endsWith(".heif");
     if (looksHeic) {
-      reportError("HEIC/HEIF isn’t reliably supported here. Please export as JPG/PNG (e.g., share → Save as JPEG, or take a screenshot).”);
+      reportError("HEIC/HEIF isn’t reliably supported here. Please export as JPG/PNG (e.g., share → Save as JPEG, or take a screenshot).");
       // We still try to decode; if it fails, the user will see the error already.
     }
 


### PR DESCRIPTION
## Summary
- replace the typographic closing quote in the HEIC/HEIF warning message with a standard double quote
- resolve the SyntaxError caused by the unterminated string constant in App.jsx

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e684d96614832aaa63c9f889ec2390