### PR TITLE
Conditionally hide drop zone overlay when preview is active

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -346,16 +346,18 @@ export default function AsciiArtApp() {
             className="relative border border-dashed rounded-3xl p-6 sm:p-8 border-neutral-300 dark:border-neutral-700 min-h-[260px] hover:bg-neutral-100/40 dark:hover:bg-neutral-900/40 transition"
           >
             {/* Full-area invisible input overlay for bulletproof tapping/clicking on mobile */}
-            <input
-              ref={overlayInputRef}
-              type="file"
-              accept="image/*"
-              capture="environment"
-              className="absolute inset-0 opacity-0 cursor-pointer"
-              title=""
-              onChange={onFileChange}
-              onClick={(e) => { e.target.value = null; }}
-            />
+            {!imageUrl && (
+              <input
+                ref={overlayInputRef}
+                type="file"
+                accept="image/*"
+                capture="environment"
+                className="absolute inset-0 opacity-0 cursor-pointer"
+                title=""
+                onChange={onFileChange}
+                onClick={(e) => { e.target.value = null; }}
+              />
+            )}
 
             {!imageUrl ? (
               <div className="text-center pointer-events-none">


### PR DESCRIPTION
## Summary
- render the full-area upload input overlay only while no image is loaded so preview controls remain interactive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e69d963d88832aa0dcfda6aa075f3c