### PR TITLE
Disable drop overlay pointer events when preview visible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -351,7 +351,9 @@ export default function AsciiArtApp() {
               type="file"
               accept="image/*"
               capture="environment"
-              className="absolute inset-0 opacity-0 cursor-pointer"
+              className={`absolute inset-0 opacity-0 ${imageUrl ? "pointer-events-none" : "cursor-pointer"}`}
+              tabIndex={imageUrl ? -1 : 0}
+              aria-hidden={imageUrl ? "true" : undefined}
               title=""
               onChange={onFileChange}
               onClick={(e) => { e.target.value = null; }}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,6 +66,16 @@ export default function AsciiArtApp() {
 
   const [urlField, setUrlField] = useState("");
 
+  const overlayInputDisabled = Boolean(imageUrl);
+  const overlayInputClassName = useMemo(
+    () =>
+      [
+        "absolute inset-0 opacity-0",
+        overlayInputDisabled ? "pointer-events-none" : "cursor-pointer",
+      ].join(" "),
+    [overlayInputDisabled],
+  );
+
   const charset = useMemo(() => CHARSETS[charsetIndex].set, [charsetIndex]);
 
   const rows = useMemo(() => {
@@ -351,9 +361,10 @@ export default function AsciiArtApp() {
               type="file"
               accept="image/*"
               capture="environment"
-              className={`absolute inset-0 opacity-0 ${imageUrl ? "pointer-events-none" : "cursor-pointer"}`}
-              tabIndex={imageUrl ? -1 : 0}
-              aria-hidden={imageUrl ? "true" : undefined}
+              className={overlayInputClassName}
+              {...(overlayInputDisabled
+                ? { tabIndex: -1, "aria-hidden": "true" }
+                : { tabIndex: 0 })}
               title=""
               onChange={onFileChange}
               onClick={(e) => { e.target.value = null; }}


### PR DESCRIPTION
## Summary
- keep the drop-zone overlay input mounted at all times for reliable change events
- disable its pointer events, tab stop, and accessibility semantics once an image preview is showing so controls remain interactive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e69d963d88832aa0dcfda6aa075f3c