### PR TITLE
Memoize drop overlay input props

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,6 +84,21 @@ export default function AsciiArtApp() {
     [fontSize, previewMinWidth],
   );
 
+  const overlayInputProps = useMemo(() => {
+    if (!imageUrl) {
+      return {
+        className: "absolute inset-0 opacity-0 cursor-pointer",
+        tabIndex: 0,
+      };
+    }
+
+    return {
+      className: "absolute inset-0 opacity-0 pointer-events-none",
+      tabIndex: -1,
+      "aria-hidden": "true",
+    };
+  }, [imageUrl]);
+
   // Clean up object URLs
   useEffect(() => () => { if (objectUrl) URL.revokeObjectURL(objectUrl); }, [objectUrl]);
 
@@ -351,12 +366,10 @@ export default function AsciiArtApp() {
               type="file"
               accept="image/*"
               capture="environment"
-              className={`absolute inset-0 opacity-0 ${imageUrl ? "pointer-events-none" : "cursor-pointer"}`}
-              tabIndex={imageUrl ? -1 : 0}
-              aria-hidden={imageUrl ? "true" : undefined}
               title=""
               onChange={onFileChange}
               onClick={(e) => { e.target.value = null; }}
+              {...overlayInputProps}
             />
 
             {!imageUrl ? (


### PR DESCRIPTION
## Summary
- memoize the drop overlay input attributes so pointer events disable cleanly when a preview is showing while keeping accessibility tweaks

## Testing
- Not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e720b78c4c832a83310341d77bd0d4