### PR TITLE
Add optional person isolation for ASCII conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tensorflow-models/coco-ssd": "^2.2.2",
+    "@tensorflow/tfjs": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Summary
- add a settings toggle to enable optional person-only ASCII rendering
- integrate on-device people detection using the TensorFlow coco-ssd model and mask non-person pixels
- cache detection results per image and gracefully fall back when detection is unavailable

## Testing
- npm install *(fails in sandbox: 403 Forbidden when fetching @tensorflow-models/coco-ssd)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1eb85a28832a8ff216a768bb5c14