### PR TITLE
Improve ASCII person isolation with BodyPix segmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tensorflow-models/body-pix": "^2.2.0",
+    "@tensorflow/tfjs": "^4.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
## Summary
- replace the coco-ssd bounding box approach with BodyPix person segmentation and map the mask onto the ASCII grid so backgrounds are removed
- smooth the segmentation mask and guard TensorFlow.js backend initialization for reliable on-device inference
- swap the coco-ssd dependency for @tensorflow-models/body-pix

## Testing
- npm install *(fails in sandbox: 403 Forbidden when fetching @tensorflow-models/body-pix)*

------
https://chatgpt.com/codex/tasks/task_e_68eb1eb85a28832a8ff216a768bb5c14