### PR TITLE
Remove unused upload refs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,8 +71,6 @@ const SUPPORTED_TYPES = new Set([
 ]);
 
 export default function AsciiArtApp() {
-  const fileInputRef = useRef(null);
-  const overlayInputRef = useRef(null);
   const dropRef = useRef(null);
 
   const [imageUrl, setImageUrl] = useState("");
@@ -745,7 +743,6 @@ export default function AsciiArtApp() {
             >
               Upload
               <input
-                ref={fileInputRef}
                 type="file"
                 accept="image/*"
                 capture="environment"
@@ -776,7 +773,6 @@ export default function AsciiArtApp() {
             {/* Full-area invisible input overlay for bulletproof tapping/clicking on mobile */}
             {!imageUrl && (
               <input
-                ref={overlayInputRef}
                 type="file"
                 accept="image/*"
                 capture="environment"


### PR DESCRIPTION
## Summary
- remove unused refs for the upload inputs in the main app component
- keep existing upload handlers intact without ref wiring

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ebb7d5703c832ab27c446e232a239d