### PR TITLE
Add Android WebView host for ASCII converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ASCII-Converter
 Turn any image into stunning ASCII art directly in your browser. Upload, drag-drop, paste, or import via URL — no server, no tracking. Features include gamma correction, colorized output, and adjustable ASCII width, all built with React + TailwindCSS.
+
+## Android version
+
+An Android host project is available in [`android/`](android/). It wraps the existing web build inside a native shell so you can ship the converter as an Android APK.
+
+### Build steps
+
+1. Install JS dependencies and produce a production build:
+   ```bash
+   npm install
+   npm run build
+   ```
+2. Copy the generated `dist/` contents into `android/app/src/main/assets/public/` (replace the placeholder HTML file).
+3. From the `android/` folder, generate a Gradle wrapper if needed with `gradle wrapper` and then build the app via `./gradlew assembleDebug` or open the project in Android Studio.
+
+See [`android/README.md`](android/README.md) for additional details.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,25 @@ An Android host project is available in [`android/`](android/). It wraps the exi
 3. From the `android/` folder, generate a Gradle wrapper if needed with `gradle wrapper` and then build the app via `./gradlew assembleDebug` or open the project in Android Studio.
 
 See [`android/README.md`](android/README.md) for additional details.
+
+## GitHub workflow: keeping web + Android side by side
+
+The Android shell lives in the `android/` subfolder, so you can keep it in the
+same repository as the existing web app. To publish both without one replacing
+the other on GitHub:
+
+1. Commit the changes from the web project **and** the `android/` directory on
+   the same branch (for example `feature/android-shell`). The root level React
+   app stays untouched, while everything Android-specific is scoped to the
+   nested folder.
+2. Open a pull request that merges the branch back into your main branch. On
+   GitHub this means you keep your original project history while adding the
+   new Android files alongside it.
+3. When you cut releases, you can continue to use GitHub Pages (or any static
+   hosting) for the web build, and optionally upload Android `.apk` artifacts
+   produced from the `android/` project as release assets. Neither workflow
+   removes the other.
+
+In short: keep the existing files in place, add the `android/` directory, and
+merge through the normal Git flow—GitHub will treat the Android host as an
+additional deliverable in the repository.

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,7 @@
+/build/
+/captures/
+/.cxx/
+/.gradle/
+/local.properties
+**/build/
+**/.DS_Store

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,31 @@
+# Android Shell App
+
+This directory contains a native Android host for the ASCII Converter web experience. The app embeds the Vite build output inside an Android WebView so the converter can run fully offline on Android devices.
+
+## Preparing the web assets
+
+1. Install the JavaScript dependencies.
+   ```bash
+   npm install
+   ```
+2. Build the production bundle.
+   ```bash
+   npm run build
+   ```
+3. Copy the generated files from `dist/` into `android/app/src/main/assets/public/`.
+   The placeholder `index.html` in that folder can be replaced entirely by the contents of `dist`.
+
+## Building the Android project
+
+1. Ensure you have the Android SDK, Java 17, and the `gradle` CLI (or Android Studio) installed locally.
+2. From the `android/` folder, generate a Gradle wrapper if one is not present yet:
+   ```bash
+   gradle wrapper
+   ```
+3. Use the wrapper to build or run the project:
+   ```bash
+   ./gradlew assembleDebug
+   ```
+4. To open the project in Android Studio, choose **Open an Existing Project** and select the `android/` directory.
+
+The `MainActivity` hosts a WebView configured with an `AssetLoader`, so the bundled files load from `https://appassets.androidplatform.net/public/index.html`. External links open in the user's default browser.

--- a/android/README.md
+++ b/android/README.md
@@ -29,3 +29,12 @@ This directory contains a native Android host for the ASCII Converter web experi
 4. To open the project in Android Studio, choose **Open an Existing Project** and select the `android/` directory.
 
 The `MainActivity` hosts a WebView configured with an `AssetLoader`, so the bundled files load from `https://appassets.androidplatform.net/public/index.html`. External links open in the user's default browser.
+
+## Keeping the Android project alongside the web app
+
+Because the native code is contained entirely within this `android/` directory,
+you can commit it directly in the same GitHub repository as the web app. When
+you push a branch that includes both the root web files and this folder, GitHub
+will simply add the Android host alongside your existing project—nothing gets
+overwritten. Use regular Git branches/PRs to merge updates, and create releases
+with both the web build and optional Android APK assets if desired.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,69 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.asciiconverter"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.asciiconverter"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.4"
+    }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.05.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.webkit:webkit:1.8.0")
+    implementation("androidx.core:core-ktx:1.13.1")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AsciiConverter">
+        <activity
+            android:name="com.example.asciiconverter.MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.AsciiConverter">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/assets/public/index.html
+++ b/android/app/src/main/assets/public/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ASCII Converter – Build Missing</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        background: #111827;
+        color: #e5e7eb;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+        text-align: center;
+      }
+      a {
+        color: #818cf8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Android build assets missing</h1>
+      <p>
+        Run <code>npm run build</code> and copy the generated <code>dist</code> folder into
+        <code>android/app/src/main/assets/public</code> to bundle the full ASCII Converter web app.
+      </p>
+    </main>
+  </body>
+</html>

--- a/android/app/src/main/java/com/example/asciiconverter/MainActivity.kt
+++ b/android/app/src/main/java/com/example/asciiconverter/MainActivity.kt
@@ -1,0 +1,79 @@
+package com.example.asciiconverter
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewCompat
+import com.example.asciiconverter.ui.theme.AsciiConverterTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AsciiConverterTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    AsciiWebView()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AsciiWebView() {
+    val context = LocalContext.current
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = {
+            val loader = WebViewAssetLoader.Builder()
+                .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(context))
+                .build()
+
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.allowFileAccess = false
+                settings.allowContentAccess = false
+                webChromeClient = WebChromeClient()
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                    ): Boolean {
+                        val url = request?.url ?: return false
+                        return if (url.host == "appassets.androidplatform.net") {
+                            false
+                        } else {
+                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url.toString())))
+                            true
+                        }
+                    }
+
+                    override fun shouldInterceptRequest(
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                    ) = WebViewCompat.shouldInterceptRequest(view, loader, request)
+                }
+                loadUrl("https://appassets.androidplatform.net/public/index.html")
+            }
+        },
+        update = { webView ->
+            if (webView.url.isNullOrBlank()) {
+                webView.loadUrl("https://appassets.androidplatform.net/public/index.html")
+            }
+        },
+    )
+}

--- a/android/app/src/main/java/com/example/asciiconverter/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/example/asciiconverter/ui/theme/Color.kt
@@ -1,0 +1,7 @@
+package com.example.asciiconverter.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val PrimaryDark = Color(0xFF1F2937)
+val PrimaryLight = Color(0xFFF3F4F6)
+val Accent = Color(0xFF6366F1)

--- a/android/app/src/main/java/com/example/asciiconverter/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/example/asciiconverter/ui/theme/Theme.kt
@@ -1,0 +1,53 @@
+package com.example.asciiconverter.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Accent,
+    onPrimary = PrimaryLight,
+    background = PrimaryDark,
+    surface = PrimaryDark,
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Accent,
+    onPrimary = PrimaryLight,
+    background = PrimaryLight,
+    surface = PrimaryLight,
+)
+
+@Composable
+fun AsciiConverterTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.background.toArgb()
+            window.navigationBarColor = colorScheme.background.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
+            }
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content,
+    )
+}

--- a/android/app/src/main/java/com/example/asciiconverter/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/example/asciiconverter/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.example.asciiconverter.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">ASCII Converter</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.AsciiConverter" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+    </style>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    kotlin("android") version "1.9.22" apply false
+}
+
+tasks.register<Delete>("clean") {
+    delete(rootProject.buildDir)
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "AsciiConverter"
+include(":app")


### PR DESCRIPTION
## Summary
- add a native Android project that wraps the existing ASCII Converter web app in a WebView shell
- wire up a Material 3 Compose theme, asset loader, and placeholder asset to host the built site offline
- document the Android build workflow in the root README and the android/README guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ebda55dd6c832aa3b1347b146376be