### PR TITLE
Address review feedback: WebView uploads and asset loading

### DIFF
--- a/android/app/src/main/java/com/example/asciiconverter/MainActivity.kt
+++ b/android/app/src/main/java/com/example/asciiconverter/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.example.asciiconverter
 
+import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -7,11 +9,18 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.webkit.ValueCallback
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
@@ -35,11 +44,43 @@ class MainActivity : ComponentActivity() {
 @Composable
 private fun AsciiWebView() {
     val context = LocalContext.current
+    var pendingFilePathCallback by remember<ValueCallback<Array<Uri>>?> { mutableStateOf(null) }
+    val fileChooserLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val callback = pendingFilePathCallback
+        if (callback == null) {
+            return@rememberLauncherForActivityResult
+        }
+
+        val uris = if (result.resultCode == Activity.RESULT_OK) {
+            val data = result.data
+            when {
+                data?.clipData != null -> {
+                    val clipData = data.clipData!!
+                    Array(clipData.itemCount) { index -> clipData.getItemAt(index).uri }
+                }
+
+                data?.data != null -> arrayOf(data.data!!)
+                else -> emptyArray()
+            }
+        } else {
+            null
+        }
+
+        if (uris == null) {
+            callback.onReceiveValue(null)
+        } else {
+            callback.onReceiveValue(uris)
+        }
+        pendingFilePathCallback = null
+    }
+
     AndroidView(
         modifier = Modifier.fillMaxSize(),
         factory = {
             val loader = WebViewAssetLoader.Builder()
-                .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(context))
+                .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(context, "public"))
                 .build()
 
             WebView(context).apply {
@@ -47,7 +88,38 @@ private fun AsciiWebView() {
                 settings.domStorageEnabled = true
                 settings.allowFileAccess = false
                 settings.allowContentAccess = false
-                webChromeClient = WebChromeClient()
+                webChromeClient = object : WebChromeClient() {
+                    override fun onShowFileChooser(
+                        webView: WebView?,
+                        callback: ValueCallback<Array<Uri>>?,
+                        fileChooserParams: FileChooserParams?,
+                    ): Boolean {
+                        val chooserCallback = callback ?: return false
+
+                        pendingFilePathCallback?.onReceiveValue(null)
+                        pendingFilePathCallback = chooserCallback
+
+                        val intent = try {
+                            fileChooserParams?.createIntent()
+                                ?: Intent(Intent.ACTION_GET_CONTENT).apply {
+                                    addCategory(Intent.CATEGORY_OPENABLE)
+                                    type = "image/*"
+                                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                                }
+                        } catch (e: ActivityNotFoundException) {
+                            pendingFilePathCallback = null
+                            return false
+                        }
+
+                        return try {
+                            fileChooserLauncher.launch(intent)
+                            true
+                        } catch (e: ActivityNotFoundException) {
+                            pendingFilePathCallback = null
+                            false
+                        }
+                    }
+                }
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(
                         view: WebView?,
@@ -67,12 +139,12 @@ private fun AsciiWebView() {
                         request: WebResourceRequest?,
                     ) = WebViewCompat.shouldInterceptRequest(view, loader, request)
                 }
-                loadUrl("https://appassets.androidplatform.net/public/index.html")
+                loadUrl("https://appassets.androidplatform.net/index.html")
             }
         },
         update = { webView ->
             if (webView.url.isNullOrBlank()) {
-                webView.loadUrl("https://appassets.androidplatform.net/public/index.html")
+                webView.loadUrl("https://appassets.androidplatform.net/index.html")
             }
         },
     )


### PR DESCRIPTION
## Summary
- implement a WebChromeClient file chooser so the Android WebView can forward selected images back to the ASCII converter
- map the asset loader to the `public/` directory and load `/index.html` so bundled JS/CSS resolve at runtime

## Testing
- ⚠️ ./gradlew -p android assembleDebug (missing Gradle wrapper in repository)


------
https://chatgpt.com/codex/tasks/task_e_68ebe78576e8832aa0dfd39550f013db