### PR TITLE
Tighten hero layout with ASCII console headline

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,20 @@ const DEFAULTS = {
   fontSize: 12,
 };
 
+const HERO_ASCII_TITLE = `
+ ____  _                       _   _        ___                          _           _ 
+/ ___|| |_ ___ _ __ ___  _ __ | |_| |__    |_ _|_ __ ___  _ __ ___   ___| |__   ___ | |
+\___ \| __/ _ \ '_ \\ _ \\| '_ \\| __| '_ \\    | || '_ \\ _ \\| '_ \\ _ \\ / _ \\ '_ \\ / _ \\| |
+ ___) | ||  __/ | | | | | |_) | |_| | | |   | || | | | | | | | | | |  __/ | | | (_) | |
+|____/ \\__\\___|_| |_| |_| .__/ \\__|_| |_|  |___|_| |_| |_|_| |_| |_|\\___|_| |_|\\___/|_|
+                        |_|                                                            
+  ____                            _      ___                _      _             
+ |  _ \\ ___ _ __ ___   ___ _ __  | |_   / _ \\__   _____  __(_) ___(_) ___  _ __  
+ | |_) / _ \\ '_  _ \\ / _ \\ '_ \\ | __| | | | \\ \\ / / _ \\/ __| |/ __| |/ _ \\| '_ \\
+ |  _ <  __/ | | | | |  __/ | | || |_  | |_| |\\ V /  __/ (__| | (__| | (_) | | | |
+ |_| \\_\\___|_| |_| |_|\\___|_| |_| \\__|  \\___/  \\_/ \\___|\\___|_|\\___|_|\\___/|_| |_|
+`.trim();
+
 // Typical monospace character aspect ratio (height / width).
 const CHAR_ASPECT = 2.0;
 
@@ -138,10 +152,10 @@ export default function AsciiArtApp() {
     const el = dropRef.current;
     if (!el) return;
 
-    const onDragOver = (e) => { e.preventDefault(); el.classList.add("ring-2","ring-indigo-500"); };
-    const onDragLeave = (e) => { e.preventDefault(); el.classList.remove("ring-2","ring-indigo-500"); };
+    const onDragOver = (e) => { e.preventDefault(); el.classList.add("ring-2", "ring-emerald-400"); };
+    const onDragLeave = (e) => { e.preventDefault(); el.classList.remove("ring-2", "ring-emerald-400"); };
     const onDrop = (e) => {
-      e.preventDefault(); el.classList.remove("ring-2","ring-indigo-500");
+      e.preventDefault(); el.classList.remove("ring-2", "ring-emerald-400");
       const files = e.dataTransfer?.files; if (files && files.length) handleFiles(files);
     };
 
@@ -567,7 +581,8 @@ export default function AsciiArtApp() {
     });
   }
 
-  const actionButtonSizing = isMobileLayout ? "flex-1 min-w-[140px]" : "";
+  const actionButtonSizing = isMobileLayout ? "flex-1 min-w-[120px]" : "";
+  const headerButtonBase = `wd-action ${actionButtonSizing}`;
   const settingsForm = (
     <>
       <div>
@@ -590,7 +605,7 @@ export default function AsciiArtApp() {
         <select
           value={charsetIndex}
           onChange={(e) => setCharsetIndex(parseInt(e.target.value))}
-          className="w-full rounded-xl border border-neutral-300 dark:border-neutral-700 bg-transparent p-2"
+          className="wd-input w-full"
         >
           {CHARSETS.map((c, i) => (
             <option key={c.name} value={i}>
@@ -664,16 +679,17 @@ export default function AsciiArtApp() {
             placeholder="https://example.com/picture.jpg"
             value={urlField}
             onChange={(e) => setUrlField(e.target.value)}
-            className="flex-1 rounded-xl border border-neutral-300 dark:border-neutral-700 bg-transparent p-2"
+            className="wd-input flex-1"
           />
           <button
             onClick={() => importFromUrl()}
-            className={`px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ${isMobileLayout ? "min-w-[96px]" : ""}`}
+            className={`wd-action ${isMobileLayout ? "min-w-[120px]" : ""}`}
+            data-tone="cyan"
           >
             Load
           </button>
         </div>
-        <p className="text-xs text-neutral-500 mt-1">We download as a blob to keep the canvas untainted.</p>
+        <p className="mt-2 text-xs text-slate-400/70">We download as a blob to keep the canvas untainted.</p>
       </div>
 
       <div className="pt-1 text-xs text-neutral-500 leading-relaxed">
@@ -688,59 +704,72 @@ export default function AsciiArtApp() {
   );
 
   return (
-    <div className="min-h-screen w-full bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100">
-      <header className="sticky top-0 z-10 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-black/40 border-b border-neutral-200/60 dark:border-neutral-800/60">
-        <div
-          className={`mx-auto max-w-6xl px-4 py-3 flex ${
-            isMobileLayout ? "flex-col gap-3" : "items-center justify-between"
-          } sm:flex-row sm:items-center sm:justify-between`}
-        >
-          <h1 className={`text-xl sm:text-2xl font-semibold ${isMobileLayout ? "sm:flex-1" : ""}`}>
-            ASCII Art Image App
-          </h1>
+    <div className="wd-app-shell min-h-screen w-full text-slate-100">
+      <header className="wd-hero sticky top-0 z-20">
+        <div className="wd-hero__grid" aria-hidden />
+        <div className="wd-hero__noise" aria-hidden />
+        <div className="relative mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:gap-10">
+          <div className="max-w-2xl space-y-4">
+            <div className="wd-hero__eyebrow">ASCII.CONSOLE // WATCH_DOGS SIGNAL</div>
+            <h1 className="wd-hero__title">
+              <span className="sr-only">Signal intercepted. Render images as ASCII.</span>
+              <div className="wd-hero__title-frame" aria-hidden="true">
+                <pre>{HERO_ASCII_TITLE}</pre>
+              </div>
+            </h1>
+            <p className="wd-hero__subtitle">
+              Jack into a monochrome grid inspired by DedSec. Feed it screenshots, photos, or glitch captures—then export razor-sharp ASCII payloads for terminals, chats, or OLED wallpapers.
+            </p>
+            <div className="wd-hero__ascii">
+              <pre>{`01000001 01010011 01000011 01001001 01001001\n>> decode.frame(signal);`}</pre>
+            </div>
+          </div>
           <div
-            className={`flex gap-2 ${
-              isMobileLayout ? "flex-wrap w-full justify-start sm:justify-end" : ""
+            className={`relative flex flex-wrap gap-2.5 ${
+              isMobileLayout ? "w-full" : "justify-end"
             }`}
           >
             <button
               onClick={copyToClipboard}
               disabled={!asciiText}
-              className={`px-3 py-2 rounded-2xl bg-neutral-900 text-white disabled:opacity-40 ${actionButtonSizing}`}
+              className={headerButtonBase}
+              data-tone="slate"
             >
               Copy
             </button>
             <button
               onClick={downloadFile}
               disabled={!asciiText}
-              className={`px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ${actionButtonSizing}`}
+              className={headerButtonBase}
+              data-tone="slate"
             >
               Download
             </button>
             <button
               onClick={downloadPng}
               disabled={!asciiCells.length}
-              className={`px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ${actionButtonSizing}`}
+              className={headerButtonBase}
+              data-tone="cyan"
             >
               Download PNG
             </button>
             <button
               onClick={downloadFullResPng}
               disabled={!asciiCells.length || !imgMeta.w || !imgMeta.h}
-              className={`px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800 ${actionButtonSizing}`}
+              className={headerButtonBase}
+              data-tone="indigo"
             >
               Download PNG (Full Res)
             </button>
             <button
               onClick={downloadOledPng}
               disabled={!asciiCells.length}
-              className={`px-3 py-2 rounded-2xl bg-neutral-900 text-white ${actionButtonSizing}`}
+              className={headerButtonBase}
+              data-tone="emerald"
             >
               Download OLED PNG
             </button>
-            <label
-              className={`px-3 py-2 rounded-2xl bg-indigo-600 text-white cursor-pointer ${actionButtonSizing}`}
-            >
+            <label className={`${headerButtonBase} cursor-pointer`} data-tone="violet">
               Upload
               <input
                 type="file"
@@ -758,16 +787,16 @@ export default function AsciiArtApp() {
       </header>
 
       <main
-        className={`mx-auto max-w-6xl px-4 py-6 ${
-          isMobileLayout ? "flex flex-col gap-6" : "grid grid-cols-1 lg:grid-cols-5 gap-6"
+        className={`mx-auto max-w-6xl px-4 py-10 ${
+          isMobileLayout ? "flex flex-col gap-8" : "grid grid-cols-1 lg:grid-cols-5 gap-8"
         }`}
       >
         {/* Dropzone / Preview */}
         <section className={isMobileLayout ? "w-full" : "lg:col-span-3"}>
           <div
             ref={dropRef}
-            className={`relative border border-dashed rounded-3xl border-neutral-300 dark:border-neutral-700 transition hover:bg-neutral-100/40 dark:hover:bg-neutral-900/40 ${
-              isMobileLayout ? "p-5 min-h-[220px]" : "p-6 sm:p-8 min-h-[260px]"
+            className={`wd-panel--inset relative overflow-hidden rounded-3xl transition ${
+              isMobileLayout ? "p-6 min-h-[240px]" : "p-8 min-h-[320px]"
             }`}
           >
             {/* Full-area invisible input overlay for bulletproof tapping/clicking on mobile */}
@@ -784,30 +813,33 @@ export default function AsciiArtApp() {
             )}
 
             {!imageUrl ? (
-              <div className="text-center pointer-events-none">
-                <div className="text-5xl mb-2">🖼️➡️🔠</div>
-                <p className="text-base">
+              <div className="pointer-events-none text-center">
+                <div className="wd-panel__header mb-4">Input channel idle</div>
+                <div className="text-4xl sm:text-5xl font-semibold tracking-[0.4em] text-cyan-200/70">
+                  ▛▞▚▚▞▟
+                </div>
+                <p className="mt-4 text-sm text-slate-300/80">
                   {isMobileLayout
-                    ? "Tap Upload above or anywhere in this box to choose or snap a photo"
-                    : "Drop, paste, click, or tap anywhere to choose an image"}
+                    ? "Tap Upload above or anywhere inside this field to jack in a photo or snap a shot."
+                    : "Drop, paste, or click to uplink an image. Clipboard intercepts with ⌘/Ctrl+V are armed."}
                 </p>
-                <p className="text-sm text-neutral-500 mt-2">
-                  {isMobileLayout
-                    ? "PNG / JPG / WEBP / GIF / BMP • Works great with the iPhone camera • Or paste an image link below"
-                    : "PNG / JPG / WEBP / GIF / BMP • Paste with ⌘/Ctrl+V • Or use an image URL below"}
+                <p className="mt-3 text-xs uppercase tracking-[0.3em] text-slate-400/70">
+                  PNG • JPG • WEBP • GIF • BMP
                 </p>
-                <div className="mt-3">
-                  <button onClick={loadDemo} className="pointer-events-auto px-3 py-2 rounded-2xl bg-neutral-200 dark:bg-neutral-800">Try a demo</button>
+                <div className="mt-5 flex justify-center">
+                  <button onClick={loadDemo} className="pointer-events-auto wd-action" data-tone="cyan">
+                    Load Demo Signal
+                  </button>
                 </div>
               </div>
             ) : (
               <div className="w-full">
-                <div className="mb-3 flex items-center justify-between text-xs text-neutral-500">
+                <div className="mb-4 flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400/70">
                   <div>Image: {imgMeta.w}×{imgMeta.h}px</div>
-                  <button onClick={clearImage} className="underline">Clear</button>
+                  <button onClick={clearImage} className="text-cyan-200 hover:text-cyan-100">Clear</button>
                 </div>
-                <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-black">
-                  <div className="max-h-[60vh] overflow-x-auto overflow-y-auto p-3">
+                <div className="wd-panel rounded-2xl">
+                  <div className="max-h-[60vh] overflow-x-auto overflow-y-auto p-4 sm:p-5">
                     {colorize ? (
                       <div
                         style={previewTextStyle}
@@ -825,7 +857,7 @@ export default function AsciiArtApp() {
             )}
 
             {error && (
-              <div className="mt-3 text-xs text-red-600 dark:text-red-400">{error}</div>
+              <div className="mt-3 text-xs uppercase tracking-[0.3em] text-rose-300/80">{error}</div>
             )}
           </div>
         </section>
@@ -834,30 +866,30 @@ export default function AsciiArtApp() {
         {isMobileLayout ? (
           <section className="lg:col-span-2">
             <details
-              className="rounded-3xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-sm"
+              className="wd-panel rounded-3xl"
               open={mobileSettingsOpen}
               onToggle={(event) => setMobileSettingsOpen(event.target.open)}
             >
               <summary className="flex items-center justify-between gap-2 px-4 py-3 text-base font-semibold cursor-pointer select-none [&::-webkit-details-marker]:hidden">
-                Settings
-                <span className="text-sm text-indigo-600">{mobileSettingsOpen ? "Hide" : "Show"}</span>
+                <span className="uppercase tracking-[0.3em] text-slate-300/80">Settings</span>
+                <span className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">{mobileSettingsOpen ? "Hide" : "Show"}</span>
               </summary>
-              <div className="border-t border-neutral-200 dark:border-neutral-800 px-4 pb-4 pt-4 sm:px-6 space-y-5">
+              <div className="border-t border-slate-700/50 px-4 pb-4 pt-4 sm:px-6 space-y-5">
                 {settingsForm}
               </div>
             </details>
           </section>
         ) : (
           <section className="lg:col-span-2">
-            <div className="rounded-3xl border border-neutral-200 dark:border-neutral-800 p-4 sm:p-6 bg-white dark:bg-neutral-950 shadow-sm space-y-5">
-              <h2 className="text-lg font-semibold">Settings</h2>
+            <div className="wd-panel rounded-3xl p-4 sm:p-6 space-y-5">
+              <h2 className="text-lg font-semibold uppercase tracking-[0.3em] text-slate-300/80">Settings</h2>
               {settingsForm}
             </div>
           </section>
         )}
       </main>
 
-      <footer className="mx-auto max-w-6xl px-4 pb-10 text-xs text-neutral-500">
+      <footer className="mx-auto max-w-6xl px-4 pb-12 text-xs wd-footer">
         Built for fun. All processing stays in your browser.
       </footer>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,290 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Share+Tech+Mono&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Optional styling tweaks */
 body {
-  @apply bg-neutral-50 dark:bg-neutral-950 text-neutral-900 dark:text-neutral-100;
+  margin: 0;
+  font-family: "IBM Plex Mono", "Share Tech Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  background-color: #02050d;
+  background-image: radial-gradient(circle at 12% 20%, rgba(16, 185, 129, 0.08) 0, transparent 55%),
+    radial-gradient(circle at 82% 18%, rgba(59, 130, 246, 0.06) 0, transparent 48%),
+    linear-gradient(180deg, #01030a 0%, #02060f 40%, #020713 100%);
+  color: #d1f1ff;
+  text-rendering: optimizeLegibility;
+}
+
+.wd-app-shell {
+  position: relative;
+  min-height: 100vh;
+  background-image: radial-gradient(circle at 10% 85%, rgba(20, 184, 166, 0.12), transparent 55%),
+    radial-gradient(circle at 90% 20%, rgba(129, 140, 248, 0.08), transparent 60%),
+    linear-gradient(160deg, rgba(2, 6, 16, 0.92), rgba(3, 10, 20, 0.95));
+  color: #c7d2fe;
+}
+
+.wd-app-shell::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(0deg, rgba(99, 102, 241, 0.03) 0, rgba(99, 102, 241, 0.03) 1px, transparent 1px, transparent 3px);
+  mix-blend-mode: screen;
+  opacity: 0.65;
+}
+
+.wd-hero {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(59, 130, 246, 0.18);
+  background: linear-gradient(140deg, rgba(2, 6, 16, 0.92) 0%, rgba(3, 12, 24, 0.94) 45%, rgba(8, 15, 32, 0.92) 100%);
+  box-shadow: 0 24px 60px -30px rgba(56, 189, 248, 0.4);
+}
+
+.wd-hero__grid,
+.wd-hero__noise {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.wd-hero__grid {
+  background-image: linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mix-blend-mode: screen;
+  opacity: 0.55;
+}
+
+.wd-hero__noise {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='64' height='64' filter='url(%23n)' opacity='0.18'/%3E%3C/svg%3E");
+  mix-blend-mode: soft-light;
+  opacity: 0.45;
+}
+
+.wd-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.32rem 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  background: rgba(6, 22, 35, 0.75);
+  color: rgba(16, 185, 129, 0.85);
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.wd-hero__title {
+  margin: 0;
+}
+
+.wd-hero__title-frame {
+  position: relative;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(56, 189, 248, 0.24);
+  background: linear-gradient(160deg, rgba(3, 12, 24, 0.7), rgba(2, 10, 20, 0.55));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+  overflow-x: auto;
+  overflow-y: hidden;
+  backdrop-filter: blur(10px) saturate(120%);
+}
+
+.wd-hero__title-frame::-webkit-scrollbar {
+  height: 4px;
+}
+
+.wd-hero__title-frame::-webkit-scrollbar-thumb {
+  background: rgba(56, 189, 248, 0.35);
+  border-radius: 9999px;
+}
+
+.wd-hero__title-frame pre {
+  margin: 0;
+  font-family: "Share Tech Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: clamp(0.42rem, 0.55vw + 0.26rem, 0.78rem);
+  line-height: 1.05;
+  letter-spacing: 0.04em;
+  color: rgba(191, 219, 254, 0.96);
+  text-shadow: 0 0 12px rgba(45, 212, 191, 0.3), 0 0 28px rgba(34, 211, 238, 0.12);
+  white-space: pre;
+  min-width: max-content;
+}
+
+.wd-hero__subtitle {
+  max-width: 28rem;
+  color: rgba(148, 163, 184, 0.78);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.wd-hero__ascii {
+  position: relative;
+  margin-top: 0.9rem;
+  padding: 0.9rem 1.05rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  background: rgba(5, 12, 22, 0.65);
+  color: rgba(94, 234, 212, 0.7);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  overflow: hidden;
+}
+
+.wd-hero__ascii::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.12), transparent 45%, rgba(16, 185, 129, 0.1));
+  mix-blend-mode: screen;
+  opacity: 0.45;
+}
+
+.wd-hero__ascii pre {
+  position: relative;
+  margin: 0;
+  white-space: pre-wrap;
+  z-index: 1;
+}
+
+.wd-action {
+  --wd-action-color: rgba(110, 231, 183, 0.95);
+  --wd-action-border: rgba(16, 185, 129, 0.5);
+  --wd-action-bg: rgba(3, 16, 24, 0.85);
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.72rem 1.15rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--wd-action-border);
+  background: linear-gradient(160deg, rgba(2, 10, 18, 0.7), var(--wd-action-bg));
+  color: var(--wd-action-color);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.wd-action::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(244, 244, 255, 0.18), transparent);
+  transform: translateX(-120%);
+  transition: transform 0.45s ease;
+  pointer-events: none;
+}
+
+.wd-action:hover::before {
+  transform: translateX(120%);
+}
+
+.wd-action:hover {
+  border-color: rgba(56, 189, 248, 0.65);
+  color: rgba(165, 243, 252, 0.95);
+  background: linear-gradient(160deg, rgba(2, 10, 18, 0.78), rgba(5, 24, 36, 0.92));
+}
+
+.wd-action:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.85);
+  outline-offset: 3px;
+}
+
+.wd-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  border-color: rgba(51, 65, 85, 0.35);
+  color: rgba(148, 163, 184, 0.55);
+  background: rgba(2, 10, 18, 0.6);
+}
+
+.wd-action[data-tone="slate"] {
+  --wd-action-color: rgba(226, 232, 240, 0.92);
+  --wd-action-border: rgba(100, 116, 139, 0.45);
+  --wd-action-bg: rgba(7, 16, 28, 0.85);
+}
+
+.wd-action[data-tone="cyan"] {
+  --wd-action-color: rgba(165, 243, 252, 0.95);
+  --wd-action-border: rgba(34, 211, 238, 0.55);
+  --wd-action-bg: rgba(3, 22, 40, 0.85);
+}
+
+.wd-action[data-tone="indigo"] {
+  --wd-action-color: rgba(199, 210, 254, 0.95);
+  --wd-action-border: rgba(129, 140, 248, 0.6);
+  --wd-action-bg: rgba(4, 18, 40, 0.88);
+}
+
+.wd-action[data-tone="emerald"] {
+  --wd-action-color: rgba(134, 239, 172, 0.95);
+  --wd-action-border: rgba(16, 185, 129, 0.55);
+  --wd-action-bg: rgba(3, 18, 20, 0.85);
+}
+
+.wd-action[data-tone="violet"] {
+  --wd-action-color: rgba(221, 214, 254, 0.95);
+  --wd-action-border: rgba(167, 139, 250, 0.6);
+  --wd-action-bg: rgba(10, 8, 32, 0.88);
+}
+
+.wd-panel {
+  position: relative;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(59, 130, 246, 0.16);
+  background: rgba(2, 12, 26, 0.82);
+  box-shadow: 0 20px 65px -35px rgba(6, 182, 212, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.wd-panel--inset {
+  border-radius: 1.5rem;
+  border-style: dashed;
+  border-width: 1.5px;
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(3, 14, 26, 0.7);
+  box-shadow: 0 24px 70px -40px rgba(56, 189, 248, 0.45);
+  backdrop-filter: blur(12px);
+  transition: border-color 0.25s ease, background 0.25s ease;
+}
+
+.wd-panel--inset:hover {
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(4, 18, 34, 0.9);
+}
+
+.wd-panel__header {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.wd-input {
+  border-radius: 0.9rem;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(2, 10, 20, 0.6);
+  color: #e0f2fe;
+  padding: 0.6rem 0.85rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.wd-input:focus-visible {
+  outline: none;
+  border-color: rgba(34, 211, 238, 0.7);
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.25);
+}
+
+.wd-footer {
+  color: rgba(148, 163, 184, 0.6);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary
- introduce a dedicated ASCII art headline block to give the hero message a console-styled treatment
- tighten hero spacing and action button sizing for a more compact Watch Dogs presentation
- refresh hero subtitle and ASCII vignette styling to match the condensed layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee5ccc5a3c832a8146b26ea00320eb