### PR TITLE
Harden clipboard copy failure handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -372,6 +372,12 @@ export default function AsciiArtApp() {
 
   function copyToClipboard() {
     if (!asciiText) return;
+    const hasClipboardApi = typeof navigator !== "undefined" && navigator.clipboard;
+    if (!hasClipboardApi) {
+      toast("Copy not supported in this browser");
+      return;
+    }
+
     if (messengerFriendly) {
       const payload = formatForMessenger(asciiText);
       if (!payload) return;
@@ -381,19 +387,31 @@ export default function AsciiArtApp() {
         .catch(() => toast("Copy failed"));
       return;
     }
+
     if (colorize && asciiHtml) {
       const htmlPayload = colorizedPreviewHtml(fontSize, asciiHtml, previewMinWidth);
       const blob = new Blob([htmlPayload], { type: "text/html" });
-      const item = new ClipboardItem({ "text/html": blob });
-      navigator.clipboard.write([item])
-        .then(() => toast("HTML copied ✨"))
-        .catch(async () => {
-          await navigator.clipboard.writeText(asciiText);
-          toast("Plain text copied (HTML fallback)");
-        });
-    } else {
-      navigator.clipboard.writeText(asciiText).then(() => toast("Copied!"));
+      if (typeof ClipboardItem === "function") {
+        const item = new ClipboardItem({ "text/html": blob });
+        navigator.clipboard.write([item])
+          .then(() => toast("HTML copied ✨"))
+          .catch(() => {
+            navigator.clipboard.writeText(asciiText)
+              .then(() => toast("Plain text copied (HTML fallback)"))
+              .catch(() => toast("Copy failed"));
+          });
+      } else {
+        navigator.clipboard.writeText(asciiText)
+          .then(() => toast("Plain text copied (HTML unsupported)"))
+          .catch(() => toast("Copy failed"));
+      }
+      return;
     }
+
+    navigator.clipboard
+      .writeText(asciiText)
+      .then(() => toast("Copied!"))
+      .catch(() => toast("Copy failed"));
   }
 
   function downloadFile() {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and unhandled promise rejections when the Clipboard API or `ClipboardItem` is unavailable. 
- Provide reliable plain-text fallbacks and clear user feedback for copy actions. 

### Description
- Add a Clipboard API availability guard at the top of `copyToClipboard` so the function exits with a toast when `navigator.clipboard` is not present. 
- Keep the `messengerFriendly` flow but ensure every `navigator.clipboard.writeText` call has a `.catch` to avoid unhandled rejections. 
- Only attempt `new ClipboardItem(...)` when `typeof ClipboardItem === "function"` and make the HTML-copy fallback robust by catching failures from the primary write and then attempting `writeText` with its own error handling. 
- Ensure normal (non-colorized) copy path also handles promise rejection with an explicit `.catch` and consistent toast messages. 

### Testing
- Ran `npm test` which passed all tests. 
- Built the production bundle with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ec64f790832a8cce992c073783f1)